### PR TITLE
Avoid consuming end of line when parsing any values

### DIFF
--- a/data/dconf.settings
+++ b/data/dconf.settings
@@ -24,13 +24,17 @@ picture-uri=' file:///home/gvolpe/Pictures/nixos.png '
 allow-volume-above-100-percent=true
 event-sounds=true
 
-[ org/gnome/desktop/wm/keybindings ]
-close=[' <Super> w ']
+[org/gnome/desktop/wm/keybindings]
+close=['<Super>w']
+switch-applications=@as []
+switch-applications-backward=@as []
+switch-windows=['<Alt>Tab']
+switch-windows-backward=['<Shift><Alt>Tab']
 
 [ org/gnome/desktop/wm/preferences ]
 button-layout=' close,minimize,maximize:'
 titlebar-font='JetBrainsMono Nerd Font Mono 11'
-workspace-names='@as []'
+workspace-names=@as []
 
 [ca/desrt/dconf-editor]
 saved-pathbar-path='/org/gnome/desktop/input-sources/'

--- a/output/dconf.nix
+++ b/output/dconf.nix
@@ -38,7 +38,11 @@ in
     };
 
     "org/gnome/desktop/wm/keybindings" = {
-      "close" = [ "<Super> w" ];
+      "close" = [ "<Super>w" ];
+      "switch-applications" = "@as []";
+      "switch-applications-backward" = "@as []";
+      "switch-windows" = [ "<Alt>Tab" ];
+      "switch-windows-backward" = [ "<Shift><Alt>Tab" ];
     };
 
     "org/gnome/desktop/wm/preferences" = {

--- a/src/DConf.hs
+++ b/src/DConf.hs
@@ -69,7 +69,7 @@ vString = try $ do
   inputs    = choice (tokens ++ files ++ shortcuts)
 
 vAny :: Parsec Text () Value
-vAny = S . T.pack <$> manyTill anyChar endOfLine
+vAny = S . T.pack <$> manyTill anyChar (try $ lookAhead endOfLine)
 
 dconf :: Parsec Text () Value
 dconf = choice


### PR DESCRIPTION
It was failing in cases like `switch-applications=@as []` when it wasn't at the end of a group.