### PR TITLE
Partial support for a list of variants + Add verbose flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ You can make changes in the UI and create a dump of your `dconf` file at any tim
 dconf dump / > dconf.settings
 ```
 
+> Note: For now, only types supported by Home Manager as specified [here](https://github.com/rycee/home-manager/blob/master/modules/lib/gvariant.nix) are supported. If there's enough interest, we might be able to work on supporting the [full specification](https://developer.gnome.org/glib/stable/gvariant-text.html).
+
 ### Run
 
 Once compiled and installed (`cabal new-install`), you can use it as follows:
@@ -79,12 +81,13 @@ Type `--help` for some more information.
 ```shell
 dconf2nix - Convert dconf files to Nix
 
-Usage: dconf2nix (-i|--input ARG) (-o|--output ARG)
+Usage: dconf2nix (-i|--input ARG) (-o|--output ARG) [-v|--verbose]
   Convert a dconf file into a Nix file, as expected by Home Manager.
 
 Available options:
   -i,--input ARG           Path to the dconf file (input)
   -o,--output ARG          Path to the Nix output file (to be created)
+  -v,--verbose             Verbose mode (debug)
   -h,--help                Show this help text
 ```
 

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -9,4 +9,4 @@ import           DConf2Nix                      ( dconf2nix )
 
 main :: IO ()
 main = runArgs >>= \case
-  (Args i o) -> dconf2nix i o
+  (Args i o v) -> dconf2nix i o v

--- a/data/dconf.settings
+++ b/data/dconf.settings
@@ -286,5 +286,12 @@ type-format='category'
 window-position=(345, 79)
 window-size=(1231, 902)
 
+[org/gnome/Weather]
+locations=[<(uint32 2, <('Gdańsk', 'EPGD', true, [(0.94916821905848536, 0.32230414101938371)], [(0.94858644845891815, 0.32579479952337237)])>)>, <(uint32 2, <('Gdynia, Działdowo County, Warmian-Masurian Voivodeship', '', false, [(0.93027949445787339, 0.34699627038777753)], [(0.93861053042695397, 0.35744550775024858)])>)>, <(uint32 2, <('Gdynia, Pomeranian Voivodeship', '', false, [(0.95149239024756216, 0.32358882203124067)], [(0.94858644845891815, 0.32579479952337237)])>)>]
+
+[org/gnome/shell/weather]
+automatic-location=true
+locations=[<(uint32 2, <('Gdańsk', 'EPGD', true, [(0.94916821905848536, 0.32230414101938371)], [(0.94858644845891815, 0.32579479952337237)])>)>, <(uint32 2, <('Gdynia, Działdowo County, Warmian-Masurian Voivodeship', '', false, [(0.93027949445787339, 0.34699627038777753)], [(0.93861053042695397, 0.35744550775024858)])>)>, <(uint32 2, <('Gdynia, Pomeranian Voivodeship', '', false, [(0.95149239024756216, 0.32358882203124067)], [(0.94858644845891815, 0.32579479952337237)])>)>]
+
 [system/locale]
 region='en_US.UTF-8'

--- a/output/dconf.nix
+++ b/output/dconf.nix
@@ -353,6 +353,15 @@ in
       "window-size" = mkTuple [ 1231 902 ];
     };
 
+    "org/gnome/Weather" = {
+      "locations" = "[<(uint32 2, <('Gdańsk', 'EPGD', true, [(0.94916821905848536, 0.32230414101938371)], [(0.94858644845891815, 0.32579479952337237)])>)>, <(uint32 2, <('Gdynia, Działdowo County, Warmian-Masurian Voivodeship', '', false, [(0.93027949445787339, 0.34699627038777753)], [(0.93861053042695397, 0.35744550775024858)])>)>, <(uint32 2, <('Gdynia, Pomeranian Voivodeship', '', false, [(0.95149239024756216, 0.32358882203124067)], [(0.94858644845891815, 0.32579479952337237)])>)>]";
+    };
+
+    "org/gnome/shell/weather" = {
+      "automatic-location" = true;
+      "locations" = "[<(uint32 2, <('Gdańsk', 'EPGD', true, [(0.94916821905848536, 0.32230414101938371)], [(0.94858644845891815, 0.32579479952337237)])>)>, <(uint32 2, <('Gdynia, Działdowo County, Warmian-Masurian Voivodeship', '', false, [(0.93027949445787339, 0.34699627038777753)], [(0.93861053042695397, 0.35744550775024858)])>)>, <(uint32 2, <('Gdynia, Pomeranian Voivodeship', '', false, [(0.95149239024756216, 0.32358882203124067)], [(0.94858644845891815, 0.32579479952337237)])>)>]";
+    };
+
     "system/locale" = {
       "region" = "en_US.UTF-8";
     };

--- a/src/CommandLine.hs
+++ b/src/CommandLine.hs
@@ -6,12 +6,14 @@ where
 
 import           DConf.Data                     ( InputFilePath(..)
                                                 , OutputFilePath(..)
+                                                , Verbosity(..)
                                                 )
 import           Options.Applicative
 
 data Args = Args
   { input :: InputFilePath
   , output :: OutputFilePath
+  , verbose :: Verbosity
   }
 
 args :: Parser Args
@@ -25,6 +27,9 @@ args =
             "Path to the Nix output file (to be created)"
           )
         )
+    <*> flag Normal
+             Verbose
+             (long "verbose" <> short 'v' <> help "Verbose mode (debug)")
 
 runArgs :: IO Args
 runArgs = execParser opts

--- a/src/DConf/Data.hs
+++ b/src/DConf/Data.hs
@@ -6,6 +6,8 @@ import           Data.Text                      ( Text )
 newtype InputFilePath = InputFilePath FilePath deriving Show
 newtype OutputFilePath = OutputFilePath FilePath deriving Show
 
+data Verbosity = Normal | Verbose
+
 newtype Nix = Nix { unNix :: Text } deriving Show
 
 newtype Key = Key Text deriving (Eq, Ord, Show)

--- a/src/DConf2Nix.hs
+++ b/src/DConf2Nix.hs
@@ -8,9 +8,9 @@ import           DConf                          ( dconfParser )
 import qualified Nix
 import           Text.Parsec.Text               ( parseFromFile )
 
-dconf2nix :: InputFilePath -> OutputFilePath -> IO ()
-dconf2nix (InputFilePath input) (OutputFilePath output) = do
-  parseFromFile dconfParser input >>= \case
+dconf2nix :: InputFilePath -> OutputFilePath -> Verbosity -> IO ()
+dconf2nix (InputFilePath input) (OutputFilePath output) v = do
+  parseFromFile (dconfParser v) input >>= \case
     Left  err -> error (show err)
     Right xs  -> do
       T.writeFile output Nix.renderHeader


### PR DESCRIPTION
Fixes #2 

It is now able to parse a list of variants as String since there is no support for this type in HM yet.