### PR TITLE
Add missing tokens + List of dictionaries

### DIFF
--- a/data/dconf.settings
+++ b/data/dconf.settings
@@ -301,3 +301,14 @@ locations=[<(uint32 2, <('Gdańsk', 'EPGD', true, [(0.94916821905848536, 0.32230
 
 [system/locale]
 region='en_US.UTF-8'
+
+[issue28/desktop/ibus/panel/emoji]
+favorites=['\8211', '\8594', '\8593', '\8595', '\8482', '\\u00ad', '\176', '\\v', '\160', '\171', '\8451']
+
+[issue28/org/gnome/desktop/input-sources]
+mru-sources=[('xkb', 'us+altgr-intl'), ('ibus', 'mozc-jp')]
+sources=[('xkb', 'us+altgr-intl'), ('ibus', 'mozc-jp')]
+nxkb-options=['terminate:ctrl_alt_bksp']
+
+[issue28/org/gnome/clocks]
+world-clocks=[{'location': <(uint32 2, <('Houston', 'KHOU', false, [(0.51727195705981943, -1.6629933445314968)], [(0.51727195705981943, -1.6629933445314968)])>)>}, {'location': <(uint32 2, <('Singapore', 'WSAP', true, [(0.023852838928353343, 1.8136879868485383)], [(0.022568084612667797, 1.8126262332513803)])>)>}]

--- a/output/dconf.nix
+++ b/output/dconf.nix
@@ -374,5 +374,19 @@ in
       region = "en_US.UTF-8";
     };
 
+    "issue28/desktop/ibus/panel/emoji" = {
+      favorites = [ "\8211" "\8594" "\8593" "\8595" "\8482" "\\u00ad" "\176" "\\v" "\160" "\171" "\8451" ];
+    };
+
+    "issue28/org/gnome/desktop/input-sources" = {
+      mru-sources = [ (mkTuple [ "xkb" "us+altgr-intl" ]) (mkTuple [ "ibus" "mozc-jp" ]) ];
+      nxkb-options = [ "terminate:ctrl_alt_bksp" ];
+      sources = [ (mkTuple [ "xkb" "us+altgr-intl" ]) (mkTuple [ "ibus" "mozc-jp" ]) ];
+    };
+
+    "issue28/org/gnome/clocks" = {
+      world-clocks = "[{'location': <(uint32 2, <('Houston', 'KHOU', false, [(0.51727195705981943, -1.6629933445314968)], [(0.51727195705981943, -1.6629933445314968)])>)>}, {'location': <(uint32 2, <('Singapore', 'WSAP', true, [(0.023852838928353343, 1.8136879868485383)], [(0.022568084612667797, 1.8126262332513803)])>)>}]";
+    };
+
   };
 }

--- a/src/DConf.hs
+++ b/src/DConf.hs
@@ -63,7 +63,7 @@ vString = try $ do
   many1 (string "'")
   S . T.pack . concat <$> manyTill inputs (string "'")
  where
-  tokens    = many1 <$> [alphaNum, space] ++ (char <$> "-_()[]{},#@")
+  tokens    = many1 <$> [alphaNum, space] ++ (char <$> "+-_()[]{},#@\\")
   files     = many1 . char <$> ":/."
   shortcuts = many1 . char <$> "<>"
   inputs    = choice (tokens ++ files ++ shortcuts)
@@ -78,7 +78,7 @@ dconf = choice
 -- There is no support for variants in HM yet so we parse them as String
 vListOfVariant :: Parsec Text () Value
 vListOfVariant = try $ do
-  try $ lookAhead (string "[<")
+  try (lookAhead $ string "[<") <|> try (lookAhead $ string "[{")
   S . T.pack <$> manyTill anyToken (try $ lookAhead endOfLine)
 
 vList :: Parsec Text () Value


### PR DESCRIPTION
Fixes #28 

@Shou notice that this fixes the issue with `emoji/favorites` and `input-sources` but `clocks` will be parsed as a simple `string` since neither `variants` nor `dictionaries` are supported by Home Manager, as described in the README file of this library.

So, after this fix, it won't fail to parse but the generated `clocks` configuration won't work once imported via `dconf`.