### PR TITLE
Use GVariant `mk` functions

### DIFF
--- a/output/clocks.nix
+++ b/output/clocks.nix
@@ -1,9 +1,8 @@
 # Generated via dconf2nix: https://github.com/gvolpe/dconf2nix
 { lib, ... }:
 
-let
-  mkTuple = lib.hm.gvariant.mkTuple;
-in
+with lib.hm.gvariant;
+
 {
   dconf.settings = {
     "org/gnome/clocks" = {

--- a/output/custom.nix
+++ b/output/custom.nix
@@ -1,9 +1,8 @@
 # Generated via dconf2nix: https://github.com/gvolpe/dconf2nix
 { lib, ... }:
 
-let
-  mkTuple = lib.hm.gvariant.mkTuple;
-in
+with lib.hm.gvariant;
+
 {
   dconf.settings = {
     "ca/desrt/dconf-editor" = {

--- a/output/dconf.nix
+++ b/output/dconf.nix
@@ -1,9 +1,8 @@
 # Generated via dconf2nix: https://github.com/gvolpe/dconf2nix
 { lib, ... }:
 
-let
-  mkTuple = lib.hm.gvariant.mkTuple;
-in
+with lib.hm.gvariant;
+
 {
   dconf.settings = {
     "org/virt-manager/virt-manager/urls" = {
@@ -97,7 +96,7 @@ in
     };
 
     "org/gnome/desktop/input-sources" = {
-      current = "uint32 0";
+      current = mkUint32 0;
       sources = [ (mkTuple [ "xkb" "us" ]) ];
       xkb-options = [ "terminate:ctrl_alt_bksp" "lv3:ralt_switch" "caps:ctrl_modifier" ];
     };
@@ -173,7 +172,7 @@ in
     };
 
     "org/gnome/desktop/session" = {
-      idle-delay = "uint32 0";
+      idle-delay = mkUint32 0;
     };
 
     "org/gnome/desktop/sound" = {
@@ -339,7 +338,7 @@ in
     };
 
     "org/gnome/software" = {
-      check-timestamp = "int64 1592897410";
+      check-timestamp = mkInt64 1592897410;
     };
 
     "org/gnome/system/location" = {

--- a/output/json.nix
+++ b/output/json.nix
@@ -1,9 +1,8 @@
 # Generated via dconf2nix: https://github.com/gvolpe/dconf2nix
 { lib, ... }:
 
-let
-  mkTuple = lib.hm.gvariant.mkTuple;
-in
+with lib.hm.gvariant;
+
 {
   dconf.settings = {
     "org/gnome/shell/extensions/sound-output-device-chooser" = {

--- a/output/negative.nix
+++ b/output/negative.nix
@@ -1,9 +1,8 @@
 # Generated via dconf2nix: https://github.com/gvolpe/dconf2nix
 { lib, ... }:
 
-let
-  mkTuple = lib.hm.gvariant.mkTuple;
-in
+with lib.hm.gvariant;
+
 {
   dconf.settings = {
     "org/gnome/settings-daemon/plugins/color" = {

--- a/output/nested.nix
+++ b/output/nested.nix
@@ -1,9 +1,8 @@
 # Generated via dconf2nix: https://github.com/gvolpe/dconf2nix
 { lib, ... }:
 
-let
-  mkTuple = lib.hm.gvariant.mkTuple;
-in
+with lib.hm.gvariant;
+
 {
   dconf.settings = {
     "org/gnome/desktop/peripherals/mouse" = {

--- a/output/quotes.nix
+++ b/output/quotes.nix
@@ -1,9 +1,8 @@
 # Generated via dconf2nix: https://github.com/gvolpe/dconf2nix
 { lib, ... }:
 
-let
-  mkTuple = lib.hm.gvariant.mkTuple;
-in
+with lib.hm.gvariant;
+
 {
   dconf.settings = {
     "org/gnome/evince" = {

--- a/src/Nix.hs
+++ b/src/Nix.hs
@@ -17,9 +17,8 @@ renderHeader = T.unlines
   [ "# Generated via dconf2nix: https://github.com/gvolpe/dconf2nix"
   , "{ lib, ... }:"
   , ""
-  , "let"
-  , "  mkTuple = lib.hm.gvariant.mkTuple;"
-  , "in"
+  , "with lib.hm.gvariant;"
+  , ""
   , "{"
   , "  dconf.settings = {"
   ]
@@ -55,8 +54,8 @@ renderValue raw = Nix $ renderValue' raw <> ";"
   renderValue' (B   v) = T.toLower . T.pack $ show v
   renderValue' (I   v) = T.pack $ show v
   renderValue' (D   v) = T.pack $ show v
-  renderValue' (I32 v) = "\"uint32 " <> T.pack (show v) <> "\""
-  renderValue' (I64 v) = "\"int64 " <> T.pack (show v) <> "\""
+  renderValue' (I32 v) = "mkUint32 " <> T.pack (show v)
+  renderValue' (I64 v) = "mkInt64 " <> T.pack (show v)
   renderValue' (T x y) =
     let wrapNegNumber x | x < 0     = "(" <> T.pack (show x) <> ")"
                         | otherwise = T.pack $ show x


### PR DESCRIPTION
closes #43 

though, `dconf2nix` does not support all the different GVariant options just yet