### PR TITLE
add support for dot in header namespaces

### DIFF
--- a/data/headers.settings
+++ b/data/headers.settings
@@ -1,0 +1,10 @@
+[gnome.desktop.interface]
+cursor-theme='Yaru'
+
+[gnome/desktop/theme]
+name="Yaru"
+
+[uk.co.ibboard.cawbird]
+round-avatars=false
+startup-accounts=['account_name']
+window-geometry={'account_name': (30, 26, 694, 1182)}

--- a/output/headers.nix
+++ b/output/headers.nix
@@ -1,0 +1,23 @@
+# Generated via dconf2nix: https://github.com/gvolpe/dconf2nix
+{ lib, ... }:
+
+with lib.hm.gvariant;
+
+{
+  dconf.settings = {
+    "gnome/desktop/interface" = {
+      cursor-theme = "Yaru";
+    };
+
+    "gnome/desktop/theme" = {
+      name = "Yaru";
+    };
+
+    "uk/co/ibboard/cawbird" = {
+      round-avatars = false;
+      startup-accounts = [ "account_name" ];
+      window-geometry = "{'account_name': (30, 26, 694, 1182)}";
+    };
+
+  };
+}

--- a/src/DConf.hs
+++ b/src/DConf.hs
@@ -115,7 +115,7 @@ dconfHeader :: Parsec Text () Header
 dconfHeader = do
   many1 (char '[') <* spaces
   T.pack . concat <$> manyTill tokens (string " ]" <|> string "]")
-  where tokens = choice $ many1 <$> [char '/', char '-', char ':', alphaNum]
+  where tokens = choice $ many1 <$> [oneOf "/.-:",  alphaNum]
 
 dconfValue :: Parsec Text () Value
 dconfValue = vListOfVariant <|> vList <|> vEmptyList <|> vJson <|> dconf endBy

--- a/src/Nix.hs
+++ b/src/Nix.hs
@@ -36,7 +36,7 @@ normalizeRoot r | T.null r           = r
 
 normalizeHeader :: Header -> Root -> Header
 normalizeHeader "/" (Root r) = T.dropWhileEnd (== '/') (normalizeRoot r)
-normalizeHeader h   (Root r) = normalizeRoot r <> h
+normalizeHeader h   (Root r) = normalizeRoot r <> T.replace "." "/" h
 
 mkSpaces :: Int -> T.Text
 mkSpaces = T.pack . flip replicate ' '

--- a/test/DConf2NixTest.hs
+++ b/test/DConf2NixTest.hs
@@ -118,5 +118,16 @@ prop_dconf2nix_scientific_notation :: Property
 prop_dconf2nix_scientific_notation =
   withTests (10 :: TestLimit) dconf2nixScientificNotation
 
+dconf2nixHeaders :: Property
+dconf2nixHeaders =
+  let input  = "data/headers.settings"
+      output = "output/headers.nix"
+      root   = Root T.empty
+  in  baseProperty input output root
+
+prop_dconf2nix_headers :: Property
+prop_dconf2nix_headers =
+  withTests (10 :: TestLimit) dconf2nixHeaders
+
 dconf2nixTests :: Group
 dconf2nixTests = $$(discover)


### PR DESCRIPTION
This PR allows headers to be defined in the following form (fixes #47):

```
[gnome.desktop.interface]
cursor-theme='Yaru'
```

But it always replaces `.` with `/` to be consistent (especially with custom roots), resulting in the following output:

```nix
"gnome/desktop/interface" = {
  cursor-theme = "Yaru";
}
```

We need confirmation that programs using such settings via `dconf` have no issues with the change from `.` to `/`. 