### PR TITLE
feature: add emoji support

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -31,7 +31,7 @@ dconf2nix (ProcessTimeout t) fa successMsg = timeout (t * 1000000) fa >>= \case
 
 main :: IO ()
 main = runArgs >>= \case
-  FileInput (FileArgs i o r t v) ->
-    dconf2nix t (dconf2nixFile i o r v) (Just "🚀 Successfully Nixified! ❄️")
-  StdinInput (StdinArgs r t v)   ->
-    dconf2nix t (dconf2nixStdin r v) Nothing
+  FileInput (FileArgs i o r t e v) ->
+    dconf2nix t (dconf2nixFile i o r e v) (Just "🚀 Successfully Nixified! ❄️")
+  StdinInput (StdinArgs r t e v)   ->
+    dconf2nix t (dconf2nixStdin r e v) Nothing

--- a/data/emoji.settings
+++ b/data/emoji.settings
@@ -1,0 +1,3 @@
+[ org/gnome/Characters ]
+recent-characters=['💡']
+some-other-character=['🤓']

--- a/dconf2nix.cabal
+++ b/dconf2nix.cabal
@@ -21,6 +21,7 @@ library
   other-modules:       Paths_dconf2nix
   build-depends:       base
                      , containers
+                     , emojis
                      , optparse-applicative
                      , parsec
                      , text

--- a/output/emoji.nix
+++ b/output/emoji.nix
@@ -1,0 +1,14 @@
+# Generated via dconf2nix: https://github.com/gvolpe/dconf2nix
+{ lib, ... }:
+
+with lib.hm.gvariant;
+
+{
+  dconf.settings = {
+    "org/gnome/Characters" = {
+      recent-characters = [ "💡" ];
+      some-other-character = [ "🤓" ];
+    };
+
+  };
+}

--- a/src/CommandLine.hs
+++ b/src/CommandLine.hs
@@ -19,12 +19,14 @@ data FileArgs = FileArgs
   , fileOutput :: OutputFilePath
   , fileRoot :: Root
   , fileTimeout :: ProcessTimeout
+  , fileEmojiSupport :: EmojiSupport
   , fileVerbosity :: Verbosity
   }
 
 data StdinArgs = StdinArgs
   { stdinRoot :: Root
   , stdinTimeout :: ProcessTimeout
+  , stdinEmojiSupport :: EmojiSupport
   , stdinVerbosity :: Verbosity
   }
 
@@ -37,6 +39,10 @@ timeoutArgs = ProcessTimeout <$> option auto
 verbosityArgs :: Parser Verbosity
 verbosityArgs =
   flag Normal Verbose (long "verbose" <> help "Verbose mode (debug)")
+
+emojiArgs :: Parser EmojiSupport
+emojiArgs =
+  flag Disabled Enabled (long "emoji" <> short 'e' <> help "Enable emoji support (adds a bit of overhead)")
 
 rootArgs :: Parser Root
 rootArgs = Root <$> strOption
@@ -56,11 +62,12 @@ fileArgs = fmap FileInput $ FileArgs
         )
     <*> rootArgs
     <*> timeoutArgs
+    <*> emojiArgs
     <*> verbosityArgs
 
 stdinArgs :: Parser Input
 stdinArgs =
-  StdinInput <$> (StdinArgs <$> rootArgs <*> timeoutArgs <*> verbosityArgs)
+  StdinInput <$> (StdinArgs <$> rootArgs <*> timeoutArgs <*> emojiArgs <*> verbosityArgs)
 
 versionInfo :: String
 versionInfo = unlines

--- a/src/DConf/Data.hs
+++ b/src/DConf/Data.hs
@@ -7,6 +7,7 @@ newtype InputFilePath = InputFilePath FilePath deriving Show
 newtype OutputFilePath = OutputFilePath FilePath deriving Show
 newtype ProcessTimeout = ProcessTimeout Int deriving Show
 
+data EmojiSupport = Enabled | Disabled
 data Verbosity = Normal | Verbose
 
 newtype Nix = Nix { unNix :: Text } deriving Show
@@ -21,6 +22,7 @@ data Value = S Text         -- String
            | I32 Int        -- Int32
            | I64 Int        -- Int64
            | D Double       -- Double
+           | Emo Char       -- Emoji (Unicode char)
            | T Value Value  -- Tuple
            | TL Value Value -- Tuple within a list
            | L [Value]      -- List of values

--- a/src/DConf2Nix.hs
+++ b/src/DConf2Nix.hs
@@ -13,16 +13,16 @@ import           Text.Parsec                    ( ParseError
                                                 , runParser
                                                 )
 
-dconf2nixFile :: InputFilePath -> OutputFilePath -> Root -> Verbosity -> IO ()
-dconf2nixFile (InputFilePath input) (OutputFilePath output) root v =
+dconf2nixFile :: InputFilePath -> OutputFilePath -> Root -> EmojiSupport -> Verbosity -> IO ()
+dconf2nixFile (InputFilePath input) (OutputFilePath output) root es v =
   let run   = handler (T.writeFile output) (T.appendFile output) root
-      parse = parseFromFile (dconfParser v) input
+      parse = parseFromFile (dconfParser es v) input
   in  run =<< parse
 
-dconf2nixStdin :: Root -> Verbosity -> IO ()
-dconf2nixStdin root v =
+dconf2nixStdin :: Root -> EmojiSupport -> Verbosity -> IO ()
+dconf2nixStdin root es v =
   let run   = handler T.putStr T.putStr root
-      parse = runParser (dconfParser v) () "<stdin>"
+      parse = runParser (dconfParser es v) () "<stdin>"
   in  run . parse =<< T.getContents
 
 handler

--- a/src/Nix.hs
+++ b/src/Nix.hs
@@ -62,6 +62,7 @@ renderValue raw = Nix $ renderValue' raw <> ";"
   renderValue' (B   v) = T.toLower . T.pack $ show v
   renderValue' (I   v) = T.pack $ show v
   renderValue' (D   v) = T.pack $ show v
+  renderValue' (Emo v) = "\"" <> T.singleton v <> "\""
   renderValue' (I32 v) = "mkUint32 " <> T.pack (show v)
   renderValue' (I64 v) = "mkInt64 " <> T.pack (show v)
   renderValue' (T x y) =

--- a/test/DConf2NixTest.hs
+++ b/test/DConf2NixTest.hs
@@ -17,8 +17,8 @@ import           Text.Parsec                    ( runParser )
 prop_dconf2nix :: Property
 prop_dconf2nix = withTests (10 :: TestLimit) dconf2nix
 
-baseProperty :: FilePath -> FilePath -> Root -> Property
-baseProperty i o root = property $ do
+baseProperty :: FilePath -> FilePath -> Root -> EmojiSupport -> Property
+baseProperty i o root es = property $ do
   input  <- evalIO $ T.readFile i
   output <- evalIO $ T.readFile o
   ref    <- evalIO $ newIORef T.empty
@@ -26,7 +26,7 @@ baseProperty i o root = property $ do
   result <- evalIO $ readIORef ref
   result === output
  where
-  entries = runParser (dconfParser Normal) () "<test>"
+  entries = runParser (dconfParser es Normal) () "<test>"
   writer ref x = modifyIORef ref (`T.append` x)
 
 dconf2nix :: Property
@@ -34,7 +34,7 @@ dconf2nix =
   let input  = "data/dconf.settings"
       output = "output/dconf.nix"
       root   = Root T.empty
-  in  baseProperty input output root
+  in  baseProperty input output root Disabled
 
 prop_dconf2nix_custom_root :: Property
 prop_dconf2nix_custom_root = withTests (10 :: TestLimit) dconf2nixCustomRoot
@@ -44,7 +44,7 @@ dconf2nixCustomRoot =
   let input  = "data/custom.settings"
       output = "output/custom.nix"
       root   = Root "ca/desrt/dconf-editor"
-  in  baseProperty input output root
+  in  baseProperty input output root Disabled
 
 prop_dconf2nix_custom_nested_root :: Property
 prop_dconf2nix_custom_nested_root =
@@ -55,14 +55,14 @@ dconf2nixCustomNestedRoot =
   let input  = "data/nested.settings"
       output = "output/nested.nix"
       root   = Root "org/gnome/desktop/peripherals"
-  in  baseProperty input output root
+  in  baseProperty input output root Disabled
 
 dconf2nixIndexer :: Property
 dconf2nixIndexer =
   let input  = "data/indexer.settings"
       output = "output/indexer.nix"
       root   = Root T.empty
-  in  baseProperty input output root
+  in  baseProperty input output root Disabled
 
 prop_dconf2nix_indexer :: Property
 prop_dconf2nix_indexer = withTests (10 :: TestLimit) dconf2nixIndexer
@@ -72,7 +72,7 @@ dconf2nixNegative =
   let input  = "data/negative.settings"
       output = "output/negative.nix"
       root   = Root T.empty
-  in  baseProperty input output root
+  in  baseProperty input output root Disabled
 
 prop_dconf2nix_negative :: Property
 prop_dconf2nix_negative = withTests (10 :: TestLimit) dconf2nixNegative
@@ -82,7 +82,7 @@ dconf2nixJson =
   let input  = "data/json.settings"
       output = "output/json.nix"
       root   = Root T.empty
-  in  baseProperty input output root
+  in  baseProperty input output root Disabled
 
 prop_dconf2nix_json :: Property
 prop_dconf2nix_json = withTests (10 :: TestLimit) dconf2nixJson
@@ -92,7 +92,7 @@ dconf2nixClocks =
   let input  = "data/clocks.settings"
       output = "output/clocks.nix"
       root   = Root T.empty
-  in  baseProperty input output root
+  in  baseProperty input output root Disabled
 
 prop_dconf2nix_clocks :: Property
 prop_dconf2nix_clocks = withTests (10 :: TestLimit) dconf2nixClocks
@@ -102,7 +102,7 @@ dconf2nixKeybindings =
   let input  = "data/keybindings.settings"
       output = "output/keybindings.nix"
       root   = Root T.empty
-  in  baseProperty input output root
+  in  baseProperty input output root Disabled
 
 prop_dconf2nix_keybindings :: Property
 prop_dconf2nix_keybindings = withTests (10 :: TestLimit) dconf2nixKeybindings
@@ -112,7 +112,7 @@ dconf2nixScientificNotation =
   let input  = "data/scientific-notation.settings"
       output = "output/scientific-notation.nix"
       root   = Root T.empty
-  in  baseProperty input output root
+  in  baseProperty input output root Disabled
 
 prop_dconf2nix_scientific_notation :: Property
 prop_dconf2nix_scientific_notation =
@@ -123,11 +123,22 @@ dconf2nixHeaders =
   let input  = "data/headers.settings"
       output = "output/headers.nix"
       root   = Root T.empty
-  in  baseProperty input output root
+  in  baseProperty input output root Disabled
 
 prop_dconf2nix_headers :: Property
 prop_dconf2nix_headers =
   withTests (10 :: TestLimit) dconf2nixHeaders
+
+dconf2nixEmoji :: Property
+dconf2nixEmoji =
+  let input  = "data/emoji.settings"
+      output = "output/emoji.nix"
+      root   = Root T.empty
+  in  baseProperty input output root Enabled
+
+prop_dconf2nix_emoji :: Property
+prop_dconf2nix_emoji =
+  withTests (10 :: TestLimit) dconf2nixEmoji
 
 dconf2nixTests :: Group
 dconf2nixTests = $$(discover)

--- a/test/DConfTest.hs
+++ b/test/DConfTest.hs
@@ -18,7 +18,7 @@ prop_simple_parser = withTests (100 :: TestLimit) simpleParser
 
 simpleParser :: Property
 simpleParser =
-  let entries = runParser (dconfParser Normal) () "<test>" testInput
+  let entries = runParser (dconfParser Disabled Normal) () "<test>" testInput
   in  property $ entries === Right [testOutput]
 
 testInput :: Text


### PR DESCRIPTION
closes #69 

The `--emoji` flag needs to be passed explicitly, as this adds a little bit of parsing overhead using the [emojis](https://hackage.haskell.org/package/emojis) package. E.g.

```console
dconf2nix -- -i data/emoji.settings -o output/emoji.nix --emoji
```