### PR TITLE
tuples: support n-arity

### DIFF
--- a/data/tuples.settings
+++ b/data/tuples.settings
@@ -1,0 +1,6 @@
+[org/gnome/tuples]
+t2=(true, 'woman')
+t3=(false, 'man', -2)
+t4=('hello', 22, 'world', true)
+n1=(false, ('xkb', 'us'), 'nested')
+n2=('hi', (true, 'us', (-787, 'lvl')), 'super-nested')

--- a/output/tuples.nix
+++ b/output/tuples.nix
@@ -1,0 +1,17 @@
+# Generated via dconf2nix: https://github.com/gvolpe/dconf2nix
+{ lib, ... }:
+
+with lib.hm.gvariant;
+
+{
+  dconf.settings = {
+    "org/gnome/tuples" = {
+      n1 = mkTuple [ false (mkTuple [ "xkb" "us" ]) "nested" ];
+      n2 = mkTuple [ "hi" (mkTuple [ true "us" (mkTuple [ (-787) "lvl" ]) ]) "super-nested" ];
+      t2 = mkTuple [ true "woman" ];
+      t3 = mkTuple [ false "man" (-2) ];
+      t4 = mkTuple [ "hello" 22 "world" true ];
+    };
+
+  };
+}

--- a/src/DConf/Data.hs
+++ b/src/DConf/Data.hs
@@ -23,8 +23,7 @@ data Value = S Text         -- String
            | I64 Int        -- Int64
            | D Double       -- Double
            | Emo Char       -- Emoji (Unicode char)
-           | T Value Value  -- Tuple
-           | TL Value Value -- Tuple within a list
+           | T [Value]      -- Tuple of n-arity
            | L [Value]      -- List of values
            | Json Text      -- Json value
            | EmptyList      -- Empty list (aka '@as []')

--- a/test/DConf2NixTest.hs
+++ b/test/DConf2NixTest.hs
@@ -132,6 +132,17 @@ prop_dconf2nix_headers :: Property
 prop_dconf2nix_headers =
   withTests (10 :: TestLimit) dconf2nixHeaders
 
+dconf2nixTuples :: Property
+dconf2nixTuples =
+  let input  = "data/tuples.settings"
+      output = "output/tuples.nix"
+      root   = Root T.empty
+  in  baseProperty' input output root
+
+prop_dconf2nix_tuples :: Property
+prop_dconf2nix_tuples =
+  withTests (10 :: TestLimit) dconf2nixTuples
+
 dconf2nixEmoji :: Property
 dconf2nixEmoji =
   let input  = "data/emoji.settings"


### PR DESCRIPTION
Closes #62  

- Simplifies the domain model (removes `TL`: tuple in a list specific data type).
- Supports nested tuples.