### PR TITLE
fix old link

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ Failing to pass the `--emoji` flag will result in a timeout error.
 
 ### Supported types
 
-For now, only types supported by Home Manager as specified [here](https://github.com/rycee/home-manager/blob/master/modules/lib/gvariant.nix) are supported. If there's enough interest, we might be able to work on supporting the [full specification](https://developer.gnome.org/glib/stable/gvariant-text.html).
+For now, only types supported by Home Manager as specified [here](https://github.com/rycee/home-manager/blob/master/modules/lib/gvariant.nix) are supported. If there's enough interest, we might be able to work on supporting the [full specification](https://docs.gtk.org/glib/gvariant-text.html).
 
 Due to the lack of support, `dconf2nix` parses dictionaries and list of variants as simple strings to avoid failing to parse a file and retain most of the information.
 


### PR DESCRIPTION
the developer.gnome.org website just redirects to gtk.org now